### PR TITLE
ci: NPM_TOKEN for release dry-run

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -78,6 +78,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEMANTIC_RELEASE_GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GH_TOKEN }}
+          # @semantic-release/npm verifyConditions requires NPM_TOKEN (same as release job).
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           if [ -n "${SEMANTIC_RELEASE_GH_TOKEN}" ]; then
             export GH_TOKEN="${SEMANTIC_RELEASE_GH_TOKEN}"

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -35,8 +35,7 @@ module.exports = {
     [
       "@semantic-release/npm",
       {
-        skipAuth: true,
-        // false until first publish + npm Trusted Publisher; then true + OIDC-only workflow.
+        // true after npm Trusted Publisher (OIDC); token-based publish uses NPM_TOKEN in CI.
         provenance: false,
       },
     ],


### PR DESCRIPTION
- `release-readiness`: set `NPM_TOKEN` so `@semantic-release/npm` verifyConditions passes in dry-run.\n- `release.config.cjs`: remove unsupported `skipAuth` (not in @semantic-release/npm v12).