### PR TITLE
ci: map NPM_SECRET to NPM_TOKEN for semantic-release

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -78,6 +78,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEMANTIC_RELEASE_GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GH_TOKEN }}
+          # @semantic-release/npm verifyConditions requires NPM_TOKEN (same as release job).
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           if [ -n "${SEMANTIC_RELEASE_GH_TOKEN}" ]; then
             export GH_TOKEN="${SEMANTIC_RELEASE_GH_TOKEN}"

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -78,15 +78,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEMANTIC_RELEASE_GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GH_TOKEN }}
-          # @semantic-release/npm verifyConditions requires NPM_TOKEN (same as release job).
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Env name must be NPM_TOKEN for @semantic-release/npm; value from repo secret NPM_SECRET.
+          NPM_TOKEN: ${{ secrets.NPM_SECRET }}
         run: |
           if [ -n "${SEMANTIC_RELEASE_GH_TOKEN}" ]; then
             export GH_TOKEN="${SEMANTIC_RELEASE_GH_TOKEN}"
           fi
           npm run release:dry-run
 
-  # Until Trusted Publisher: NPM_TOKEN + always-auth + registry-url (see gist). Then OIDC-only.
+  # Until Trusted Publisher: npm token secret + always-auth + registry-url (see gist). Then OIDC-only.
   release:
     needs: [lint, format, test, release-readiness]
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta')
@@ -108,13 +108,14 @@ jobs:
           always-auth: true
           registry-url: https://registry.npmjs.org
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_SECRET }}
       - run: npm ci
       - run: npm run build
       - name: Semantic release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_SECRET }}
+          NPM_TOKEN: ${{ secrets.NPM_SECRET }}
           SEMANTIC_RELEASE_GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GH_TOKEN }}
         run: |
           if [ -n "${SEMANTIC_RELEASE_GH_TOKEN}" ]; then

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -35,8 +35,7 @@ module.exports = {
     [
       "@semantic-release/npm",
       {
-        skipAuth: true,
-        // false until first publish + npm Trusted Publisher; then true + OIDC-only workflow.
+        // true after npm Trusted Publisher (OIDC); token-based publish uses NPM_TOKEN in CI.
         provenance: false,
       },
     ],

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -35,7 +35,7 @@ module.exports = {
     [
       "@semantic-release/npm",
       {
-        // true after npm Trusted Publisher (OIDC); token-based publish uses NPM_TOKEN in CI.
+        // true after npm Trusted Publisher (OIDC); CI maps repo secret NPM_SECRET to env NPM_TOKEN.
         provenance: false,
       },
     ],


### PR DESCRIPTION
Workflow referenced `secrets.NPM_TOKEN` while the repo secret is `NPM_SECRET`. Use `secrets.NPM_SECRET` for `NPM_TOKEN` / `NODE_AUTH_TOKEN`. Comment update in `release.config.cjs`.