### PR TITLE
Extract Geologica wordmark as SVG assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # queryd
 
 <p align="left">
-  <img src="./docs/assets/queryd-wordmark.png" alt="queryd" width="280" />
+  <img src="./docs/assets/queryd-wordmark-dark.svg" alt="queryd" width="240" height="62" />
 </p>
 
 [![CI](https://img.shields.io/github/actions/workflow/status/oleg-koval/slow-query-detector/ci-release.yml?branch=main&logo=github&label=ci)](https://github.com/oleg-koval/slow-query-detector/actions/workflows/ci-release.yml?query=branch%3Amain)

--- a/docs/assets/queryd-wordmark-dark.svg
+++ b/docs/assets/queryd-wordmark-dark.svg
@@ -20,7 +20,7 @@
   </defs>
   <text x="0" y="38" class="logotype">quer</text>
   <text x="80" y="38" class="logotype">y</text>
-  <g transform="translate(74, 7) scale(1.06)" aria-hidden="true">
+  <g transform="translate(72, 20) scale(1.06)" aria-hidden="true">
     <path class="pulse" d="M0 5h3.2l1.8-3.2 2.4 6.4 2-3.2H20" />
   </g>
   <text x="98" y="38" class="logotype">d</text>

--- a/docs/assets/queryd-wordmark-dark.svg
+++ b/docs/assets/queryd-wordmark-dark.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 52" role="img" aria-label="queryd">
+  <defs>
+    <style>
+      @import url("https://fonts.googleapis.com/css2?family=Geologica:wght@700&amp;display=swap");
+      .logotype {
+        font-family: "Geologica", system-ui, -apple-system, "Segoe UI", sans-serif;
+        font-weight: 700;
+        font-size: 36px;
+        letter-spacing: -0.045em;
+        fill: #12151c;
+      }
+      .pulse {
+        fill: none;
+        stroke: #2a7d6e;
+        stroke-width: 1.45;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+      }
+    </style>
+  </defs>
+  <text x="0" y="38" class="logotype">quer</text>
+  <text x="80" y="38" class="logotype">y</text>
+  <g transform="translate(74, 7) scale(1.06)" aria-hidden="true">
+    <path class="pulse" d="M0 5h3.2l1.8-3.2 2.4 6.4 2-3.2H20" />
+  </g>
+  <text x="98" y="38" class="logotype">d</text>
+</svg>

--- a/docs/assets/queryd-wordmark.svg
+++ b/docs/assets/queryd-wordmark.svg
@@ -20,7 +20,7 @@
   </defs>
   <text x="0" y="38" class="logotype">quer</text>
   <text x="80" y="38" class="logotype">y</text>
-  <g transform="translate(74, 7) scale(1.06)" aria-hidden="true">
+  <g transform="translate(72, 20) scale(1.06)" aria-hidden="true">
     <path class="pulse" d="M0 5h3.2l1.8-3.2 2.4 6.4 2-3.2H20" />
   </g>
   <text x="98" y="38" class="logotype">d</text>

--- a/docs/assets/queryd-wordmark.svg
+++ b/docs/assets/queryd-wordmark.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 52" role="img" aria-label="queryd">
+  <defs>
+    <style>
+      @import url("https://fonts.googleapis.com/css2?family=Geologica:wght@700&amp;display=swap");
+      .logotype {
+        font-family: "Geologica", system-ui, -apple-system, "Segoe UI", sans-serif;
+        font-weight: 700;
+        font-size: 36px;
+        letter-spacing: -0.045em;
+        fill: #e8eaef;
+      }
+      .pulse {
+        fill: none;
+        stroke: #5fb8a8;
+        stroke-width: 1.45;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+      }
+    </style>
+  </defs>
+  <text x="0" y="38" class="logotype">quer</text>
+  <text x="80" y="38" class="logotype">y</text>
+  <g transform="translate(74, 7) scale(1.06)" aria-hidden="true">
+    <path class="pulse" d="M0 5h3.2l1.8-3.2 2.4 6.4 2-3.2H20" />
+  </g>
+  <text x="98" y="38" class="logotype">d</text>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -162,36 +162,23 @@
         flex-wrap: wrap;
       }
 
-      .wordmark {
-        font-family: var(--font-display);
-        font-weight: 700;
-        font-size: 1.35rem;
-        letter-spacing: -0.045em;
-        color: var(--fg);
+      .brand-link {
         display: inline-flex;
-        align-items: baseline;
-        line-height: 1;
+        align-items: center;
+        line-height: 0;
       }
 
-      .wordmark--hero {
-        font-size: clamp(2.75rem, 7.5vw, 4.5rem);
+      .brand-mark {
+        height: 1.75rem;
+        width: auto;
+        display: block;
+      }
+
+      .hero-mark {
+        width: min(22rem, 100%);
+        height: auto;
+        display: block;
         margin: 0 0 var(--space-5);
-      }
-
-      .wm-y {
-        position: relative;
-        display: inline-block;
-      }
-
-      .wm-pulse {
-        position: absolute;
-        left: 52%;
-        top: 48%;
-        width: 0.95em;
-        height: 0.48em;
-        transform: translate(-50%, -50%);
-        color: var(--accent);
-        pointer-events: none;
       }
 
       .nav-links {
@@ -485,18 +472,15 @@
     <a class="skip" href="#main">Skip to content</a>
     <header>
       <div class="wrap nav">
-        <a class="wordmark" href="./" aria-label="queryd — home">
-          quer<span class="wm-y"
-            >y<svg class="wm-pulse" viewBox="0 0 20 10" aria-hidden="true" focusable="false">
-              <path
-                d="M0 5h3.2l1.8-3.2 2.4 6.4 2-3.2H20"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.35"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              /></svg></span
-          >d
+        <a class="brand-link" href="./" aria-label="queryd — home">
+          <img
+            class="brand-mark"
+            src="./assets/queryd-wordmark.svg"
+            alt=""
+            width="200"
+            height="52"
+            decoding="async"
+          />
         </a>
         <nav class="nav-links" aria-label="Primary">
           <a class="pill" href="https://github.com/oleg-koval/slow-query-detector">Repository</a>
@@ -513,19 +497,15 @@
             <span class="pulse-dot" aria-hidden="true"></span>
             Early-stage OSS · pin a version in <code>0.x</code>
           </div>
-          <div class="wordmark wordmark--hero reveal" aria-hidden="true">
-            quer<span class="wm-y"
-              >y<svg class="wm-pulse" viewBox="0 0 20 10" aria-hidden="true" focusable="false">
-                <path
-                  d="M0 5h3.2l1.8-3.2 2.4 6.4 2-3.2H20"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.35"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                /></svg></span
-            >d
-          </div>
+          <img
+            class="hero-mark reveal"
+            src="./assets/queryd-wordmark.svg"
+            alt=""
+            width="200"
+            height="52"
+            decoding="async"
+            aria-hidden="true"
+          />
           <h1 class="reveal">Latency budgets for the SQL your Node app actually runs.</h1>
           <p class="lede reveal">
             <strong>queryd</strong> is a database query latency detector for Node.js with first-class Prisma support

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -30,7 +30,14 @@ module.exports = {
     { name: "beta", channel: "beta", prerelease: "beta" },
   ],
   plugins: [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        preset: "angular",
+        // Custom rules run first; unmatched commits still use the plugin defaults (feat/fix/perf, etc.).
+        releaseRules: [{ type: "docs", release: "patch" }],
+      },
+    ],
     "@semantic-release/release-notes-generator",
     [
       "@semantic-release/npm",


### PR DESCRIPTION
Adds `queryd-wordmark.svg` (light on dark) and `queryd-wordmark-dark.svg` (dark on light) with the same pulse geometry. GitHub Pages uses the light variant; README uses the dark variant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated branding logo assets from PNG to SVG format with adjusted sizing.
  * Refactored wordmark rendering to use external image assets instead of inline styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->