### PR TITLE
Per-request query budgets and documentation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,12 @@ await runWithDbContext({ requestId: "req-abc", userId: "user-42" }, async () => 
 ### `wrapQueryFn` (string SQL)
 
 ```ts
-import { createSlowQueryDetector, wrapQueryFn, createConsoleLogger, runWithDbContext } from "@olegkoval/queryd";
+import {
+  createSlowQueryDetector,
+  wrapQueryFn,
+  createConsoleLogger,
+  runWithDbContext,
+} from "@olegkoval/queryd";
 
 const rawQuery = async (sql: string, params: unknown[]) => {
   /* your client */

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Node](https://img.shields.io/node/v/@olegkoval%2Fqueryd.svg?logo=node.js&label=node)](https://nodejs.org/)
 [![GitHub Pages](https://img.shields.io/badge/docs-GitHub%20Pages-5eead4)](https://oleg-koval.github.io/slow-query-detector/)
 
-**queryd** is a database query latency detector for Node.js: **driver-agnostic** hooks (`wrapQueryFn`, `wrapTaggedTemplate`, `SlowQueryDetector.executeQuery`), optional **Prisma** integration behind `@olegkoval/queryd/prisma`, sampling, optional `EXPLAIN ANALYZE`, and pluggable sinks.
+**queryd** is a database query latency detector for Node.js: **driver-agnostic** hooks (`wrapQueryFn`, `wrapTaggedTemplate`, `SlowQueryDetector.executeQuery`), optional **Prisma** integration behind `@olegkoval/queryd/prisma`, sampling, optional **per-request query budgets**, optional `EXPLAIN ANALYZE`, and pluggable sinks.
 
 Project site: [oleg-koval.github.io/slow-query-detector](https://oleg-koval.github.io/slow-query-detector/).
 
@@ -24,11 +24,15 @@ Add `@prisma/client` only if you use the Prisma entry (see below).
 
 ## Usage (any stack)
 
-`SlowQueryDetector.executeQuery` runs your callback and emits `QueryEvent`s. Wrappers cover common shapes:
+`SlowQueryDetector.executeQuery` runs your callback and emits structured events (`QueryEvent` for each query, and optionally `RequestBudgetViolationEvent` — see [Request budgets](#request-budgets-per-requestid)). Wrappers cover common shapes:
 
 - **`wrapQueryFn`** — `(sql: string, params?) => Promise<unknown>` (raw clients, thin DB helpers).
 - **`wrapTaggedTemplate`** — tagged template `(strings, ...values) => Promise<unknown>` (e.g. **postgres.js** `sql`, same literal shape as Prisma `$queryRaw`).
 - **`extractQueryInfo`** — build `$1…$n` SQL + params from a `TemplateStringsArray` if you wire a custom executor.
+
+### postgres.js (tagged template + request scope)
+
+Use **`runWithDbContext`** so each HTTP request (or job) gets a stable **`requestId`**; **`createSlowQueryDetector`** defaults `contextProvider` to **`getDbContext()`**, so you usually do **not** pass `contextProvider` unless you merge ALS with your own source.
 
 ```ts
 import postgres from "postgres";
@@ -36,16 +40,57 @@ import {
   createSlowQueryDetector,
   wrapTaggedTemplate,
   createConsoleLogger,
+  runWithDbContext,
 } from "@olegkoval/queryd";
 
 const sql = postgres(process.env.DATABASE_URL!);
 const detector = createSlowQueryDetector(
-  { warnThresholdMs: 200, dbName: "primary" },
+  {
+    warnThresholdMs: 200,
+    dbName: "primary",
+    requestBudget: { maxQueries: 80, maxTotalDurationMs: 2_000 },
+  },
   { logger: createConsoleLogger() },
 );
 const instrumentedSql = wrapTaggedTemplate(sql, detector);
-await instrumentedSql`SELECT ${1}::int`;
+
+await runWithDbContext({ requestId: "req-abc", userId: "user-42" }, async () => {
+  await instrumentedSql`select ${1}::int`;
+  await instrumentedSql`select ${2}::int`;
+});
 ```
+
+### `wrapQueryFn` (string SQL)
+
+```ts
+import { createSlowQueryDetector, wrapQueryFn, createConsoleLogger, runWithDbContext } from "@olegkoval/queryd";
+
+const rawQuery = async (sql: string, params: unknown[]) => {
+  /* your client */
+  return [];
+};
+const detector = createSlowQueryDetector(
+  { warnThresholdMs: 200, requestBudget: { maxQueries: 50 } },
+  { logger: createConsoleLogger() },
+);
+const q = wrapQueryFn(rawQuery, detector);
+
+await runWithDbContext({ requestId: "job-7" }, async () => {
+  await q("select 1", []);
+});
+```
+
+## Request budgets (per `requestId`)
+
+Set `requestBudget.maxQueries` and/or `requestBudget.maxTotalDurationMs` to catch **query storms** (many fast queries) that stay under single-query latency thresholds. Counts and duration are summed **per `requestId`** for the lifetime of that id in the LRU map (in-process only).
+
+- **Successful and failed** `executeQuery` completions both increment the budget (every round-trip attempt counts).
+- The first time a limit is exceeded for a `requestId`, sinks receive one **`db.request.budget`** event (`LoggerSink` → **warn**). A second violation for the same id is only possible after that id falls out of the LRU (e.g. many concurrent requests with unique ids).
+- **`requestBudget.maxTrackedRequests`** bounds memory (default **5000**); non-finite or `< 1` values are normalized.
+
+**Custom sinks:** `IEventSink.handle` receives **`DetectorEvent`** (`QueryEvent | RequestBudgetViolationEvent`). Branch on `event.event === "db.request.budget"` before assuming `sql` / `subtype` exist.
+
+**Advanced:** `new SlowQueryDetector(config, undefined, sinks)` does **not** install the default `getDbContext()` provider — use **`createSlowQueryDetector`** or pass `contextProvider: { getContext: () => getDbContext() }` if you construct the detector yourself.
 
 ## Prisma
 
@@ -60,7 +105,11 @@ import { wrapPrismaClient } from "@olegkoval/queryd/prisma";
 
 const base = new PrismaClient();
 const detector = createSlowQueryDetector(
-  { warnThresholdMs: 200, dbName: "primary" },
+  {
+    warnThresholdMs: 200,
+    dbName: "primary",
+    requestBudget: { maxQueries: 80, maxTotalDurationMs: 2_000 },
+  },
   { logger: createConsoleLogger() },
 );
 export const prisma = wrapPrismaClient(base, detector);
@@ -69,6 +118,8 @@ await runWithDbContext({ requestId: "req-1", userId: "u-1" }, async () => {
   await prisma.$queryRaw`SELECT 1`;
 });
 ```
+
+`wrapPrismaClient` lives on **`@olegkoval/queryd/prisma`** so the core package stays free of a hard `@prisma/client` dependency. The Prisma path is the same **`requestBudget` + `runWithDbContext`** pattern as the driver-agnostic examples above.
 
 ### Sentry / other backends
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,12 +9,12 @@
     <title>queryd — slow query detection for Node.js</title>
     <meta
       name="description"
-      content="queryd detects database query latency in Node.js. Prisma-friendly budgets, sampling, and optional EXPLAIN — early-stage OSS."
+      content="queryd detects database query latency in Node.js: driver-agnostic wrappers (postgres.js, raw SQL), optional Prisma via @olegkoval/queryd/prisma, per-request budgets, sampling, optional EXPLAIN."
     />
     <meta property="og:title" content="queryd" />
     <meta
       property="og:description"
-      content="Database query latency detector for Node.js — budgets, sampling, optional EXPLAIN."
+      content="Driver-agnostic slow query detection for Node.js — per-request budgets, Prisma subpath, sampling, optional EXPLAIN."
     />
     <meta property="og:type" content="website" />
     <meta
@@ -39,7 +39,7 @@
         "@context": "https://schema.org",
         "@type": "SoftwareSourceCode",
         "name": "queryd",
-        "description": "Database query latency detector for Node.js with Prisma-friendly integration.",
+        "description": "Database query latency detector for Node.js with driver-agnostic wrappers and optional Prisma integration.",
         "license": "https://opensource.org/licenses/MIT",
         "codeRepository": "https://github.com/oleg-koval/slow-query-detector",
         "programmingLanguage": ["TypeScript", "JavaScript"],
@@ -330,6 +330,10 @@
         overflow: hidden;
       }
 
+      .code-panel + .code-panel {
+        margin-top: var(--space-5);
+      }
+
       .code-panel__head {
         display: flex;
         align-items: center;
@@ -459,6 +463,9 @@
       .reveal:nth-child(6) {
         animation-delay: 0.27s;
       }
+      .reveal:nth-child(7) {
+        animation-delay: 0.32s;
+      }
 
       @keyframes rise {
         to {
@@ -508,9 +515,10 @@
           />
           <h1 class="reveal">Latency budgets for the SQL your Node app actually runs.</h1>
           <p class="lede reveal">
-            <strong>queryd</strong> is a database query latency detector for Node.js with first-class Prisma support
-            (<code>$queryRaw</code>, <code>$executeRaw</code>, interactive <code>$transaction</code>), sampling,
-            optional <code>EXPLAIN ANALYZE</code>, and pluggable sinks.
+            <strong>queryd</strong> wraps the SQL your app actually runs — tagged templates (e.g. postgres.js), string SQL
+            (<code>wrapQueryFn</code>), or Prisma via <code>@olegkoval/queryd/prisma</code> — with per-query latency
+            thresholds, optional <strong>per-<code>requestId</code> query budgets</strong>, sampling, optional
+            <code>EXPLAIN ANALYZE</code>, and pluggable sinks.
           </p>
           <div class="cta-row reveal">
             <a class="pill primary" href="https://www.npmjs.com/package/@olegkoval/queryd">Install from npm</a>
@@ -523,8 +531,11 @@
               <p>Flag database work that exceeds a latency threshold so regressions surface before users feel them.</p>
             </article>
             <article class="card reveal">
-              <h3>Prisma-shaped path</h3>
-              <p>Designed for common Node + ORM setups; the goal is ergonomic hooks instead of hand-rolled timers.</p>
+              <h3>Driver-agnostic core</h3>
+              <p>
+                <code>wrapTaggedTemplate</code> and <code>wrapQueryFn</code> instrument real clients; Prisma lives on
+                <code>@olegkoval/queryd/prisma</code> so the base package stays lean.
+              </p>
             </article>
             <article class="card reveal">
               <h3>Predictable overhead</h3>
@@ -541,7 +552,7 @@
               <span class="code-panel__label">Usage · Prisma</span>
               <div class="code-panel__meta">
                 <span class="lang-tag">TypeScript</span>
-                <button type="button" class="copy-btn" id="copy-snippet" aria-label="Copy code sample">
+                <button type="button" class="copy-btn" data-copy-for="snippet-pre" aria-label="Copy Prisma code sample">
                   Copy
                 </button>
               </div>
@@ -549,20 +560,58 @@
             <pre id="snippet-pre"><code><span class="tok-k">import</span> { <span class="tok-t">PrismaClient</span> } <span class="tok-k">from</span> <span class="tok-s">"@prisma/client"</span>;
 <span class="tok-k">import</span> {
   <span class="tok-t">createSlowQueryDetector</span>,
-  <span class="tok-t">wrapPrismaClient</span>,
   <span class="tok-t">createConsoleLogger</span>,
   <span class="tok-t">runWithDbContext</span>,
 } <span class="tok-k">from</span> <span class="tok-s">"@olegkoval/queryd"</span>;
+<span class="tok-k">import</span> { <span class="tok-t">wrapPrismaClient</span> } <span class="tok-k">from</span> <span class="tok-s">"@olegkoval/queryd/prisma"</span>;
 
 <span class="tok-k">const</span> base = <span class="tok-k">new</span> <span class="tok-f">PrismaClient</span>();
 <span class="tok-k">const</span> detector = <span class="tok-f">createSlowQueryDetector</span>(
-  { warnThresholdMs: <span class="tok-t">200</span>, dbName: <span class="tok-s">"primary"</span> },
+  {
+    warnThresholdMs: <span class="tok-t">200</span>,
+    dbName: <span class="tok-s">"primary"</span>,
+    requestBudget: { maxQueries: <span class="tok-t">80</span>, maxTotalDurationMs: <span class="tok-t">2000</span> },
+  },
   { logger: <span class="tok-f">createConsoleLogger</span>() },
 );
 <span class="tok-k">export const</span> prisma = <span class="tok-f">wrapPrismaClient</span>(base, detector);
 
 <span class="tok-k">await</span> <span class="tok-f">runWithDbContext</span>({ requestId: <span class="tok-s">"req-1"</span>, userId: <span class="tok-s">"u-1"</span> }, <span class="tok-k">async</span> () => {
   <span class="tok-k">await</span> prisma.$queryRaw<span class="tok-s">`SELECT 1`</span>;
+});</code></pre>
+          </div>
+
+          <div class="code-panel reveal">
+            <div class="code-panel__head">
+              <span class="code-panel__label">Usage · postgres.js</span>
+              <div class="code-panel__meta">
+                <span class="lang-tag">TypeScript</span>
+                <button type="button" class="copy-btn" data-copy-for="snippet-pre-pg" aria-label="Copy postgres.js code sample">
+                  Copy
+                </button>
+              </div>
+            </div>
+            <pre id="snippet-pre-pg"><code><span class="tok-k">import</span> postgres <span class="tok-k">from</span> <span class="tok-s">"postgres"</span>;
+<span class="tok-k">import</span> {
+  <span class="tok-t">createSlowQueryDetector</span>,
+  <span class="tok-t">wrapTaggedTemplate</span>,
+  <span class="tok-t">createConsoleLogger</span>,
+  <span class="tok-t">runWithDbContext</span>,
+} <span class="tok-k">from</span> <span class="tok-s">"@olegkoval/queryd"</span>;
+
+<span class="tok-k">const</span> sql = <span class="tok-f">postgres</span>(process.env.<span class="tok-t">DATABASE_URL</span>!);
+<span class="tok-k">const</span> detector = <span class="tok-f">createSlowQueryDetector</span>(
+  {
+    warnThresholdMs: <span class="tok-t">200</span>,
+    dbName: <span class="tok-s">"primary"</span>,
+    requestBudget: { maxQueries: <span class="tok-t">80</span>, maxTotalDurationMs: <span class="tok-t">2000</span> },
+  },
+  { logger: <span class="tok-f">createConsoleLogger</span>() },
+);
+<span class="tok-k">const</span> instrumentedSql = <span class="tok-f">wrapTaggedTemplate</span>(sql, detector);
+
+<span class="tok-k">await</span> <span class="tok-f">runWithDbContext</span>({ requestId: <span class="tok-s">"req-abc"</span> }, <span class="tok-k">async</span> () => {
+  <span class="tok-k">await</span> instrumentedSql<span class="tok-s">`select ${1}::int`</span>;
 });</code></pre>
           </div>
         </div>
@@ -576,22 +625,24 @@
     </main>
     <script>
       (function () {
-        var btn = document.getElementById("copy-snippet");
-        var pre = document.getElementById("snippet-pre");
-        if (!btn || !pre) return;
-        btn.addEventListener("click", function () {
-          var text = pre.innerText;
-          if (navigator.clipboard && navigator.clipboard.writeText) {
-            navigator.clipboard.writeText(text).then(function () {
-              btn.setAttribute("data-copied", "true");
-              var t = btn.textContent;
-              btn.textContent = "Copied";
-              setTimeout(function () {
-                btn.textContent = t;
-                btn.removeAttribute("data-copied");
-              }, 2000);
-            });
-          }
+        document.querySelectorAll(".copy-btn[data-copy-for]").forEach(function (btn) {
+          var id = btn.getAttribute("data-copy-for");
+          var pre = id ? document.getElementById(id) : null;
+          if (!pre) return;
+          btn.addEventListener("click", function () {
+            var text = pre.innerText;
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+              navigator.clipboard.writeText(text).then(function () {
+                btn.setAttribute("data-copied", "true");
+                var t = btn.textContent;
+                btn.textContent = "Copied";
+                setTimeout(function () {
+                  btn.textContent = t;
+                  btn.removeAttribute("data-copied");
+                }, 2000);
+              });
+            }
+          });
         });
       })();
     </script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="canonical" href="https://oleg-koval.github.io/slow-query-detector/" />
     <meta name="color-scheme" content="dark" />
-    <meta name="theme-color" content="oklch(0.13 0.014 240)" />
+    <meta name="theme-color" content="oklch(0.14 0.012 240)" />
     <title>queryd — slow query detection for Node.js</title>
     <meta
       name="description"
@@ -51,17 +51,17 @@
       :root {
         --hue: 238;
         --accent-hue: 168;
-        --bg-deep: oklch(0.12 0.018 var(--hue));
-        --bg-raised: oklch(0.16 0.02 var(--hue));
-        --bg-code: oklch(0.1 0.015 var(--hue));
-        --fg: oklch(0.93 0.012 var(--hue));
-        --fg-soft: oklch(0.72 0.028 var(--hue));
-        --line: color-mix(in oklch, var(--fg) 12%, transparent);
-        --accent: oklch(0.72 0.11 var(--accent-hue));
-        --accent-soft: color-mix(in oklch, var(--accent) 22%, transparent);
+        --bg-deep: oklch(0.14 0.012 var(--hue));
+        --bg-raised: oklch(0.17 0.014 var(--hue));
+        --bg-code: oklch(0.12 0.012 var(--hue));
+        --fg: oklch(0.92 0.01 var(--hue));
+        --fg-soft: oklch(0.7 0.022 var(--hue));
+        --line: color-mix(in oklch, var(--fg) 10%, transparent);
+        --accent: oklch(0.68 0.075 var(--accent-hue));
+        --accent-soft: color-mix(in oklch, var(--accent) 16%, transparent);
         --radius-sm: 10px;
         --radius-md: 14px;
-        --radius-lg: 20px;
+        --radius-lg: 18px;
         --space-3: 12px;
         --space-4: 16px;
         --space-5: 24px;
@@ -71,7 +71,8 @@
         --font-body: "Literata", "Georgia", serif;
         --font-display: "Geologica", system-ui, sans-serif;
         --font-mono: "JetBrains Mono", ui-monospace, monospace;
-        --shadow: 0 28px 90px oklch(0.05 0.02 var(--hue) / 0.55);
+        --shadow: 0 12px 32px oklch(0.06 0.015 var(--hue) / 0.28);
+        --shadow-soft: 0 1px 0 oklch(0.5 0.02 var(--hue) / 0.06);
       }
 
       *,
@@ -103,12 +104,6 @@
         line-height: 1.62;
         color: var(--fg);
         background: var(--bg-deep);
-        background-image: radial-gradient(
-            ellipse 100% 80% at 0% -20%,
-            oklch(0.22 0.04 var(--accent-hue) / 0.12),
-            transparent 55%
-          ),
-          radial-gradient(ellipse 70% 50% at 100% 0%, oklch(0.2 0.035 var(--hue) / 0.2), transparent 45%);
       }
 
       a {
@@ -147,8 +142,7 @@
       header {
         padding: var(--space-5) 0 var(--space-4);
         border-bottom: 1px solid var(--line);
-        background: color-mix(in oklch, var(--bg-deep) 88%, transparent);
-        backdrop-filter: blur(12px);
+        background: var(--bg-deep);
         position: sticky;
         top: 0;
         z-index: 10;
@@ -201,23 +195,24 @@
         font-weight: 500;
         letter-spacing: 0.01em;
         color: var(--fg);
-        background: oklch(0.18 0.018 var(--hue) / 0.65);
-        transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+        background: var(--bg-raised);
+        box-shadow: var(--shadow-soft);
+        transition: border-color 0.18s ease, background 0.18s ease, color 0.18s ease;
       }
 
       .pill:hover {
-        border-color: color-mix(in oklch, var(--accent) 55%, var(--line));
-        background: oklch(0.2 0.022 var(--hue) / 0.85);
+        border-color: color-mix(in oklch, var(--accent) 40%, var(--line));
+        background: oklch(0.19 0.016 var(--hue));
       }
 
       .pill.primary {
-        border-color: color-mix(in oklch, var(--accent) 45%, var(--line));
+        border-color: color-mix(in oklch, var(--accent) 32%, var(--line));
         background: var(--accent-soft);
         color: var(--fg);
       }
 
       .pill.primary:hover {
-        background: color-mix(in oklch, var(--accent) 28%, var(--bg-raised));
+        background: color-mix(in oklch, var(--accent) 22%, var(--bg-raised));
       }
 
       main {
@@ -246,15 +241,15 @@
         font-weight: 500;
         letter-spacing: 0.02em;
         margin-bottom: var(--space-5);
-        background: oklch(0.17 0.02 var(--hue) / 0.55);
+        background: var(--bg-raised);
       }
 
       .pulse-dot {
-        width: 7px;
-        height: 7px;
+        width: 6px;
+        height: 6px;
         border-radius: 50%;
         background: var(--accent);
-        box-shadow: 0 0 0 5px var(--accent-soft);
+        opacity: 0.85;
         flex-shrink: 0;
       }
 
@@ -298,12 +293,8 @@
         border: 1px solid var(--line);
         border-radius: var(--radius-lg);
         padding: var(--space-5) var(--space-5) var(--space-4);
-        background: linear-gradient(
-          155deg,
-          oklch(0.2 0.022 var(--hue) / 0.55),
-          oklch(0.14 0.016 var(--hue) / 0.35)
-        );
-        box-shadow: var(--shadow);
+        background: var(--bg-raised);
+        box-shadow: var(--shadow-soft);
       }
 
       .card h3 {
@@ -325,7 +316,7 @@
         border-radius: var(--radius-lg);
         border: 1px solid var(--line);
         background: var(--bg-code);
-        box-shadow: var(--shadow);
+        box-shadow: var(--shadow-soft);
         text-align: start;
         overflow: hidden;
       }
@@ -342,7 +333,7 @@
         flex-wrap: wrap;
         padding: var(--space-3) var(--space-4);
         border-bottom: 1px solid var(--line);
-        background: oklch(0.14 0.016 var(--hue) / 0.9);
+        background: var(--bg-raised);
       }
 
       .code-panel__label {
@@ -444,8 +435,8 @@
 
       .reveal {
         opacity: 0;
-        transform: translateY(14px);
-        animation: rise 0.75s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+        transform: translateY(8px);
+        animation: rise 0.55s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
       }
 
       .reveal:nth-child(2) {
@@ -465,6 +456,12 @@
       }
       .reveal:nth-child(7) {
         animation-delay: 0.32s;
+      }
+      .reveal:nth-child(8) {
+        animation-delay: 0.37s;
+      }
+      .reveal:nth-child(9) {
+        animation-delay: 0.42s;
       }
 
       @keyframes rise {
@@ -612,6 +609,38 @@
 
 <span class="tok-k">await</span> <span class="tok-f">runWithDbContext</span>({ requestId: <span class="tok-s">"req-abc"</span> }, <span class="tok-k">async</span> () => {
   <span class="tok-k">await</span> instrumentedSql<span class="tok-s">`select ${1}::int`</span>;
+});</code></pre>
+          </div>
+
+          <div class="code-panel reveal">
+            <div class="code-panel__head">
+              <span class="code-panel__label">Usage · wrapQueryFn</span>
+              <div class="code-panel__meta">
+                <span class="lang-tag">TypeScript</span>
+                <button type="button" class="copy-btn" data-copy-for="snippet-pre-wqf" aria-label="Copy wrapQueryFn code sample">
+                  Copy
+                </button>
+              </div>
+            </div>
+            <pre id="snippet-pre-wqf"><code><span class="tok-k">import</span> {
+  <span class="tok-t">createSlowQueryDetector</span>,
+  <span class="tok-t">wrapQueryFn</span>,
+  <span class="tok-t">createConsoleLogger</span>,
+  <span class="tok-t">runWithDbContext</span>,
+} <span class="tok-k">from</span> <span class="tok-s">"@olegkoval/queryd"</span>;
+
+<span class="tok-k">const</span> rawQuery = <span class="tok-k">async</span> (sql: <span class="tok-t">string</span>, params: <span class="tok-t">unknown</span>[]) => {
+  <span class="tok-c">/* your client */</span>
+  <span class="tok-k">return</span> [];
+};
+<span class="tok-k">const</span> detector = <span class="tok-f">createSlowQueryDetector</span>(
+  { warnThresholdMs: <span class="tok-t">200</span>, requestBudget: { maxQueries: <span class="tok-t">50</span> } },
+  { logger: <span class="tok-f">createConsoleLogger</span>() },
+);
+<span class="tok-k">const</span> q = <span class="tok-f">wrapQueryFn</span>(rawQuery, detector);
+
+<span class="tok-k">await</span> <span class="tok-f">runWithDbContext</span>({ requestId: <span class="tok-s">"job-7"</span> }, <span class="tok-k">async</span> () => {
+  <span class="tok-k">await</span> q(<span class="tok-s">"select 1"</span>, []);
 });</code></pre>
           </div>
         </div>

--- a/src/__tests__/context.test.ts
+++ b/src/__tests__/context.test.ts
@@ -18,7 +18,11 @@ describe("slowQueryDetector context", () => {
   });
 
   it("resolveDetectorContext swallows provider errors", () => {
-    const provider = { getContext: (): never => { throw new Error("boom"); } };
+    const provider = {
+      getContext: (): never => {
+        throw new Error("boom");
+      },
+    };
     expect(resolveDetectorContext(provider)).toEqual({});
   });
 });

--- a/src/__tests__/context.test.ts
+++ b/src/__tests__/context.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getDbContext, runWithDbContext } from "../context";
+import { getDbContext, resolveDetectorContext, runWithDbContext } from "../context";
 
 describe("slowQueryDetector context", () => {
   it("provides context within run scope", async () => {
@@ -11,5 +11,14 @@ describe("slowQueryDetector context", () => {
 
   it("returns empty context outside scope", () => {
     expect(getDbContext()).toEqual({});
+  });
+
+  it("resolveDetectorContext returns empty when provider missing", () => {
+    expect(resolveDetectorContext(undefined)).toEqual({});
+  });
+
+  it("resolveDetectorContext swallows provider errors", () => {
+    const provider = { getContext: (): never => { throw new Error("boom"); } };
+    expect(resolveDetectorContext(provider)).toEqual({});
   });
 });

--- a/src/__tests__/createSlowQueryDetector.contract.test.ts
+++ b/src/__tests__/createSlowQueryDetector.contract.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Factory behavior that affects production integration (array mutation, sink wiring).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { createSlowQueryDetector, runWithDbContext } from "../index";
+import { LoggerSink } from "../sinks/loggerSink";
+import type { DetectorEvent, IEventSink, ILogger } from "../types";
+
+describe("createSlowQueryDetector (contract)", () => {
+  it("mutates the sinks array in-place when appending a LoggerSink", () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as ILogger;
+    const sinks: IEventSink[] = [];
+    createSlowQueryDetector({ warnThresholdMs: 200 }, { logger, sinks });
+    expect(sinks.length).toBe(1);
+    expect(sinks[0]).toBeInstanceOf(LoggerSink);
+  });
+
+  it("delivers db.request.budget events to custom sinks that accept DetectorEvent", async () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as ILogger;
+    const events: DetectorEvent["event"][] = [];
+    const custom: IEventSink = {
+      handle(e: DetectorEvent): void {
+        events.push(e.event);
+      },
+    };
+    const detector = createSlowQueryDetector(
+      { warnThresholdMs: 999_999, requestBudget: { maxQueries: 0 } },
+      {
+        logger,
+        sinks: [custom],
+        contextProvider: { getContext: () => ({ requestId: "custom-sink-contract" }) },
+      },
+    );
+
+    await detector.executeQuery(async () => [], { sql: "SELECT 1", params: [] });
+
+    expect(events).toContain("db.query");
+    expect(events).toContain("db.request.budget");
+  });
+
+  it("defaults context to getDbContext so runWithDbContext works without explicit contextProvider", async () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as ILogger;
+    const detector = createSlowQueryDetector(
+      { warnThresholdMs: 999_999, requestBudget: { maxQueries: 0 } },
+      { logger },
+    );
+
+    await runWithDbContext({ requestId: "factory-als" }, async () => {
+      await detector.executeQuery(async () => [], { sql: "SELECT 1", params: [] });
+    });
+
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/detector.test.ts
+++ b/src/__tests__/detector.test.ts
@@ -3,8 +3,15 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { runWithDbContext } from "../context";
 import { SlowQueryDetector } from "../detector";
-import type { ILogger, IEventSink, QueryEvent } from "../types";
+import type {
+  ILogger,
+  IEventSink,
+  QueryEvent,
+  DetectorEvent,
+  RequestBudgetViolationEvent,
+} from "../types";
 import { LoggerSink } from "../sinks/loggerSink";
 
 describe("detector", () => {
@@ -115,5 +122,125 @@ describe("detector", () => {
     const event = sinkHandle.mock.calls[0][0] as QueryEvent;
     expect(event.requestId).toBe("req-123");
     expect(event.userId).toBe("user-456");
+  });
+
+  it("should emit request budget violation once when maxQueries exceeded", async () => {
+    const contextProvider = {
+      getContext: () => ({ requestId: "req-budget", userId: "u" }),
+    };
+    const detector = new SlowQueryDetector(
+      { warnThresholdMs: 999_999, requestBudget: { maxQueries: 2 } },
+      contextProvider,
+      [mockSink],
+    );
+
+    for (let i = 0; i < 3; i++) {
+      await detector.executeQuery(async () => [], { sql: `SELECT ${i}`, params: [] });
+    }
+
+    const events = sinkHandle.mock.calls.map((c) => c[0] as DetectorEvent);
+    expect(events.filter((e) => e.event === "db.request.budget")).toHaveLength(1);
+    expect(events.filter((e) => e.event === "db.query")).toHaveLength(3);
+  });
+
+  it("counts failed queries toward request budget (same as successful)", async () => {
+    const contextProvider = {
+      getContext: () => ({ requestId: "req-err-budget" }),
+    };
+    const detector = new SlowQueryDetector(
+      { warnThresholdMs: 999_999, requestBudget: { maxQueries: 1 } },
+      contextProvider,
+      [mockSink],
+    );
+
+    await expect(
+      detector.executeQuery(async () => {
+        throw new Error("fail-one");
+      }, { sql: "SELECT 1", params: [] }),
+    ).rejects.toThrow("fail-one");
+
+    await expect(
+      detector.executeQuery(async () => {
+        throw new Error("fail-two");
+      }, { sql: "SELECT 2", params: [] }),
+    ).rejects.toThrow("fail-two");
+
+    const budgets = sinkHandle.mock.calls
+      .map((c) => c[0])
+      .filter((e): e is RequestBudgetViolationEvent => {
+        return (
+          typeof e === "object" &&
+          e !== null &&
+          "event" in e &&
+          (e as { event: string }).event === "db.request.budget"
+        );
+      });
+    expect(budgets).toHaveLength(1);
+    expect(budgets[0]?.queryCount).toBe(2);
+
+    const errors = sinkHandle.mock.calls
+      .map((c) => c[0])
+      .filter((e): e is QueryEvent => {
+        return (
+          typeof e === "object" &&
+          e !== null &&
+          "event" in e &&
+          (e as QueryEvent).event === "db.query" &&
+          (e as QueryEvent).subtype === "error"
+        );
+      });
+    expect(errors).toHaveLength(2);
+  });
+
+  it("does not read AsyncLocalStorage when contextProvider is undefined (factory vs constructor)", async () => {
+    const detector = new SlowQueryDetector(
+      { warnThresholdMs: 999_999, requestBudget: { maxQueries: 1 } },
+      undefined,
+      [mockSink],
+    );
+
+    await runWithDbContext({ requestId: "als-only" }, async () => {
+      await detector.executeQuery(async () => [], { sql: "SELECT 1", params: [] });
+      await detector.executeQuery(async () => [], { sql: "SELECT 2", params: [] });
+    });
+
+    const budgets = sinkHandle.mock.calls.filter(
+      (c) =>
+        typeof c[0] === "object" &&
+        c[0] !== null &&
+        (c[0] as { event?: string }).event === "db.request.budget",
+    );
+    expect(budgets).toHaveLength(0);
+  });
+
+  it("emits only one budget violation when a second configured limit would also be exceeded later", async () => {
+    const contextProvider = {
+      getContext: () => ({ requestId: "dual-limit" }),
+    };
+    const detector = new SlowQueryDetector(
+      {
+        warnThresholdMs: 999_999,
+        requestBudget: { maxQueries: 2, maxTotalDurationMs: 1_000_000 },
+      },
+      contextProvider,
+      [mockSink],
+    );
+
+    for (let i = 0; i < 3; i++) {
+      await detector.executeQuery(async () => [], { sql: `SELECT ${i}`, params: [] });
+    }
+
+    await detector.executeQuery(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      return [];
+    }, { sql: "SELECT slow", params: [] });
+
+    const budgetEvents = sinkHandle.mock.calls.filter(
+      (c) =>
+        typeof c[0] === "object" &&
+        c[0] !== null &&
+        (c[0] as { event?: string }).event === "db.request.budget",
+    );
+    expect(budgetEvents).toHaveLength(1);
   });
 });

--- a/src/__tests__/detector.test.ts
+++ b/src/__tests__/detector.test.ts
@@ -154,15 +154,21 @@ describe("detector", () => {
     );
 
     await expect(
-      detector.executeQuery(async () => {
-        throw new Error("fail-one");
-      }, { sql: "SELECT 1", params: [] }),
+      detector.executeQuery(
+        async () => {
+          throw new Error("fail-one");
+        },
+        { sql: "SELECT 1", params: [] },
+      ),
     ).rejects.toThrow("fail-one");
 
     await expect(
-      detector.executeQuery(async () => {
-        throw new Error("fail-two");
-      }, { sql: "SELECT 2", params: [] }),
+      detector.executeQuery(
+        async () => {
+          throw new Error("fail-two");
+        },
+        { sql: "SELECT 2", params: [] },
+      ),
     ).rejects.toThrow("fail-two");
 
     const budgets = sinkHandle.mock.calls
@@ -230,10 +236,13 @@ describe("detector", () => {
       await detector.executeQuery(async () => [], { sql: `SELECT ${i}`, params: [] });
     }
 
-    await detector.executeQuery(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 30));
-      return [];
-    }, { sql: "SELECT slow", params: [] });
+    await detector.executeQuery(
+      async () => {
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        return [];
+      },
+      { sql: "SELECT slow", params: [] },
+    );
 
     const budgetEvents = sinkHandle.mock.calls.filter(
       (c) =>

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createSlowQueryDetector } from "../index";
+import { createSlowQueryDetector, runWithDbContext, wrapTaggedTemplate } from "../index";
 import { wrapPrismaClient } from "../prisma";
 import type { ILogger, IContextProvider } from "../types";
 import type { PrismaClient } from "@prisma/client";
@@ -164,5 +164,32 @@ describe("integration", () => {
     });
 
     expect(txQueryRaw).toHaveBeenCalledTimes(2);
+  });
+
+  it("should emit request budget via wrapTaggedTemplate and runWithDbContext", async () => {
+    const detector = createSlowQueryDetector(
+      {
+        warnThresholdMs: 999_999,
+        requestBudget: { maxQueries: 2 },
+        sampleRateNormal: 0,
+      },
+      { logger: mockLogger },
+    );
+    const exec = vi.fn().mockResolvedValue([]);
+    const wrapped = wrapTaggedTemplate(exec, detector);
+
+    await runWithDbContext({ requestId: "req-budget", userId: "u-1" }, async () => {
+      await wrapped`SELECT 1`;
+      await wrapped`SELECT 2`;
+      await wrapped`SELECT 3`;
+    });
+
+    const budgetWarnings = mockWarn.mock.calls.filter(
+      (c) =>
+        typeof c[0] === "object" &&
+        c[0] !== null &&
+        (c[0] as { event?: string }).event === "db.request.budget",
+    );
+    expect(budgetWarnings).toHaveLength(1);
   });
 });

--- a/src/__tests__/loggerSink.test.ts
+++ b/src/__tests__/loggerSink.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { LoggerSink } from "../sinks/loggerSink";
-import type { QueryEvent, ILogger } from "../types";
+import type { QueryEvent, ILogger, RequestBudgetViolationEvent } from "../types";
 
 describe("loggerSink", () => {
   let mockLogger: ILogger;
@@ -86,6 +86,25 @@ describe("loggerSink", () => {
     sink.handle(event);
 
     expect(mockLogger.info).toHaveBeenCalledWith(event);
+  });
+
+  it("should log request budget violations with logger.warn", () => {
+    const sink = new LoggerSink(mockLogger, {});
+    const event: RequestBudgetViolationEvent = {
+      event: "db.request.budget",
+      subtype: "violation",
+      timestamp: new Date().toISOString(),
+      requestId: "req-1",
+      queryCount: 50,
+      totalDurationMs: 120,
+      maxQueries: 30,
+    };
+
+    sink.handle(event);
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(event);
+    expect(mockLogger.error).not.toHaveBeenCalled();
+    expect(mockLogger.info).not.toHaveBeenCalled();
   });
 
   it("should not log normal events when sampleRateNormal is 0", () => {

--- a/src/__tests__/requestBudget-review-scenarios.test.ts
+++ b/src/__tests__/requestBudget-review-scenarios.test.ts
@@ -41,10 +41,13 @@ describe("request budget review scenarios", () => {
       queueMicrotask(() => resolve());
     });
 
-    const first = detector.executeQuery(async () => {
-      await barrier;
-      return [];
-    }, { sql: "awaits-microtask", params: [] });
+    const first = detector.executeQuery(
+      async () => {
+        await barrier;
+        return [];
+      },
+      { sql: "awaits-microtask", params: [] },
+    );
 
     const second = detector.executeQuery(async () => [], { sql: "sync-empty", params: [] });
 
@@ -68,7 +71,12 @@ describe("request budget review scenarios", () => {
 
     const violation = sinkHandle.mock.calls
       .map((c) => c[0])
-      .find((e) => typeof e === "object" && e !== null && (e as { event?: string }).event === "db.request.budget");
+      .find(
+        (e) =>
+          typeof e === "object" &&
+          e !== null &&
+          (e as { event?: string }).event === "db.request.budget",
+      );
     expect(violation).toMatchObject({ requestId: " " });
   });
 });

--- a/src/__tests__/requestBudget-review-scenarios.test.ts
+++ b/src/__tests__/requestBudget-review-scenarios.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Encodes production-surprise scenarios from adversarial review (each scenario = executable spec).
+ * Not every scenario implies a bug — many document intentional or edge behavior.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { RequestBudgetTracker } from "../requestBudgetTracker";
+import { SlowQueryDetector } from "../detector";
+import type { DetectorEvent, IEventSink, QueryEvent } from "../types";
+
+describe("request budget review scenarios", () => {
+  it("uses independent Maps per RequestBudgetTracker instance (no cross-process sharing)", () => {
+    const a = new RequestBudgetTracker(100);
+    const b = new RequestBudgetTracker(100);
+    const budget = { maxQueries: 0 };
+    expect(a.record("shared-key", undefined, 1, budget, undefined)).toMatchObject({
+      event: "db.request.budget",
+    });
+    expect(b.record("shared-key", undefined, 1, budget, undefined)).toMatchObject({
+      event: "db.request.budget",
+    });
+  });
+
+  it("orders overlapping query finally blocks by completion (sync before awaited microtask)", async () => {
+    const contextProvider = { getContext: () => ({ requestId: "overlap-order" }) };
+    const sqlOrder: string[] = [];
+    const sink: IEventSink = {
+      handle(e: DetectorEvent): void {
+        if (e.event === "db.query") {
+          sqlOrder.push((e as QueryEvent).sql);
+        }
+      },
+    };
+    const detector = new SlowQueryDetector(
+      { warnThresholdMs: 999_999, requestBudget: { maxQueries: 5 } },
+      contextProvider,
+      [sink],
+    );
+
+    const barrier = new Promise<void>((resolve) => {
+      queueMicrotask(() => resolve());
+    });
+
+    const first = detector.executeQuery(async () => {
+      await barrier;
+      return [];
+    }, { sql: "awaits-microtask", params: [] });
+
+    const second = detector.executeQuery(async () => [], { sql: "sync-empty", params: [] });
+
+    await Promise.all([first, second]);
+
+    expect(sqlOrder[0]).toBe("sync-empty");
+    expect(sqlOrder[1]).toBe("awaits-microtask");
+  });
+
+  it("treats whitespace-only requestId as a real budget key (not trimmed to empty)", async () => {
+    const sinkHandle = vi.fn();
+    const mockSink: IEventSink = { handle: sinkHandle };
+    const contextProvider = { getContext: () => ({ requestId: " " }) };
+    const detector = new SlowQueryDetector(
+      { warnThresholdMs: 999_999, requestBudget: { maxQueries: 0 } },
+      contextProvider,
+      [mockSink],
+    );
+
+    await detector.executeQuery(async () => [], { sql: "Q", params: [] });
+
+    const violation = sinkHandle.mock.calls
+      .map((c) => c[0])
+      .find((e) => typeof e === "object" && e !== null && (e as { event?: string }).event === "db.request.budget");
+    expect(violation).toMatchObject({ requestId: " " });
+  });
+});

--- a/src/__tests__/requestBudgetTracker.test.ts
+++ b/src/__tests__/requestBudgetTracker.test.ts
@@ -141,9 +141,7 @@ describe("RequestBudgetTracker", () => {
   it("accepts very long requestId strings without throwing", () => {
     const t = new RequestBudgetTracker(100);
     const id = "z".repeat(20_000);
-    expect(() =>
-      t.record(id, undefined, 1, { maxQueries: 1 }, undefined),
-    ).not.toThrow();
+    expect(() => t.record(id, undefined, 1, { maxQueries: 1 }, undefined)).not.toThrow();
   });
 
   it("clamps non-positive maxTrackedRequests to a single LRU slot", () => {

--- a/src/__tests__/requestBudgetTracker.test.ts
+++ b/src/__tests__/requestBudgetTracker.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Request budget tracker tests
+ */
+
+import { describe, it, expect } from "vitest";
+import { RequestBudgetTracker } from "../requestBudgetTracker";
+
+describe("RequestBudgetTracker", () => {
+  it("emits violation when query count exceeds maxQueries", () => {
+    const t = new RequestBudgetTracker(100);
+    const budget = { maxQueries: 2 };
+    expect(t.record("r1", undefined, 1, budget, "db")).toBeUndefined();
+    expect(t.record("r1", undefined, 1, budget, "db")).toBeUndefined();
+    const v = t.record("r1", undefined, 1, budget, "db");
+    expect(v).toMatchObject({
+      event: "db.request.budget",
+      requestId: "r1",
+      queryCount: 3,
+      maxQueries: 2,
+      dbName: "db",
+    });
+    expect(t.record("r1", undefined, 1, budget, "db")).toBeUndefined();
+  });
+
+  it("emits violation when total duration exceeds maxTotalDurationMs", () => {
+    const t = new RequestBudgetTracker(100);
+    const budget = { maxTotalDurationMs: 25 };
+    expect(t.record("r2", "u1", 10, budget, undefined)).toBeUndefined();
+    expect(t.record("r2", "u1", 10, budget, undefined)).toBeUndefined();
+    const v = t.record("r2", "u1", 10, budget, undefined);
+    expect(v).toMatchObject({
+      event: "db.request.budget",
+      requestId: "r2",
+      userId: "u1",
+      totalDurationMs: 30,
+      maxTotalDurationMs: 25,
+    });
+  });
+
+  it("evicts oldest request when over capacity", () => {
+    const t = new RequestBudgetTracker(2);
+    const budget = { maxQueries: 10 };
+    t.record("a", undefined, 1, budget, undefined);
+    t.record("b", undefined, 1, budget, undefined);
+    t.record("c", undefined, 1, budget, undefined);
+    expect(t.record("a", undefined, 1, budget, undefined)).toBeUndefined();
+  });
+
+  it("violates on first query when maxQueries is 0", () => {
+    const t = new RequestBudgetTracker(100);
+    const budget = { maxQueries: 0 };
+    const v = t.record("zero", undefined, 1, budget, undefined);
+    expect(v).toMatchObject({
+      event: "db.request.budget",
+      requestId: "zero",
+      queryCount: 1,
+      maxQueries: 0,
+    });
+  });
+
+  it("treats non-finite maxTrackedRequests like the default pool size", () => {
+    const baseline = new RequestBudgetTracker(undefined);
+    const fromInf = new RequestBudgetTracker(Number.POSITIVE_INFINITY);
+    const fromNaN = new RequestBudgetTracker(Number.NaN);
+    const budget = { maxQueries: 2 };
+    for (const tracker of [baseline, fromInf, fromNaN]) {
+      expect(tracker.record("r", undefined, 1, budget, undefined)).toBeUndefined();
+      expect(tracker.record("r", undefined, 1, budget, undefined)).toBeUndefined();
+      expect(tracker.record("r", undefined, 1, budget, undefined)).toMatchObject({
+        event: "db.request.budget",
+        requestId: "r",
+        queryCount: 3,
+      });
+    }
+  });
+
+  it("never raises maxTotalDurationMs when every durationMs is zero", () => {
+    const t = new RequestBudgetTracker(100);
+    const budget = { maxTotalDurationMs: 5 };
+    for (let i = 0; i < 30; i++) {
+      expect(t.record("all-zero", undefined, 0, budget, undefined)).toBeUndefined();
+    }
+  });
+
+  it("does not trip maxTotalDurationMs when summed duration becomes NaN", () => {
+    const t = new RequestBudgetTracker(100);
+    const budget = { maxTotalDurationMs: 10 };
+    expect(t.record("nan-dur", undefined, Number.NaN, budget, undefined)).toBeUndefined();
+    expect(t.record("nan-dur", undefined, Number.NaN, budget, undefined)).toBeUndefined();
+    expect(t.record("nan-dur", undefined, 1, budget, undefined)).toBeUndefined();
+  });
+
+  it("never violates on query count when maxQueries is positive Infinity", () => {
+    const t = new RequestBudgetTracker(50);
+    const budget = { maxQueries: Number.POSITIVE_INFINITY };
+    for (let i = 0; i < 20; i++) {
+      expect(t.record("inf-cap", undefined, 1, budget, undefined)).toBeUndefined();
+    }
+  });
+
+  it("never violates on query count when maxQueries is NaN", () => {
+    const t = new RequestBudgetTracker(50);
+    const budget = { maxQueries: Number.NaN };
+    for (let i = 0; i < 5; i++) {
+      expect(t.record("nan-q", undefined, 1, budget, undefined)).toBeUndefined();
+    }
+  });
+
+  it("treats negative maxTotalDurationMs as an immediately exceeded time cap", () => {
+    const t = new RequestBudgetTracker(10);
+    const budget = { maxTotalDurationMs: -1 };
+    expect(t.record("neg-total", undefined, 1, budget, undefined)).toMatchObject({
+      event: "db.request.budget",
+      totalDurationMs: 1,
+      maxTotalDurationMs: -1,
+    });
+  });
+
+  it("violates on first positive duration when maxTotalDurationMs is 0", () => {
+    const t = new RequestBudgetTracker(10);
+    const budget = { maxTotalDurationMs: 0 };
+    expect(t.record("t0", undefined, 1, budget, undefined)).toMatchObject({
+      event: "db.request.budget",
+      totalDurationMs: 1,
+      maxTotalDurationMs: 0,
+    });
+  });
+
+  it("floors fractional maxTrackedRequests for eviction capacity", () => {
+    const floored = new RequestBudgetTracker(2.9);
+    const exact = new RequestBudgetTracker(2);
+    const budget = { maxQueries: 10 };
+    for (const tracker of [floored, exact]) {
+      tracker.record("a", undefined, 1, budget, undefined);
+      tracker.record("b", undefined, 1, budget, undefined);
+      tracker.record("c", undefined, 1, budget, undefined);
+      expect(tracker.record("a", undefined, 1, budget, undefined)).toBeUndefined();
+    }
+  });
+
+  it("accepts very long requestId strings without throwing", () => {
+    const t = new RequestBudgetTracker(100);
+    const id = "z".repeat(20_000);
+    expect(() =>
+      t.record(id, undefined, 1, { maxQueries: 1 }, undefined),
+    ).not.toThrow();
+  });
+
+  it("clamps non-positive maxTrackedRequests to a single LRU slot", () => {
+    // Same requestId string can violate again after eviction (new Map entry).
+    const t = new RequestBudgetTracker(0);
+    const budget = { maxQueries: 2 };
+    expect(t.record("p1", undefined, 1, budget, undefined)).toBeUndefined();
+    expect(t.record("p1", undefined, 1, budget, undefined)).toBeUndefined();
+    expect(t.record("p1", undefined, 1, budget, undefined)).toMatchObject({
+      event: "db.request.budget",
+      requestId: "p1",
+    });
+    expect(t.record("p2", undefined, 1, budget, undefined)).toBeUndefined();
+    expect(t.record("p1", undefined, 1, budget, undefined)).toBeUndefined();
+    expect(t.record("p1", undefined, 1, budget, undefined)).toBeUndefined();
+    expect(t.record("p1", undefined, 1, budget, undefined)).toMatchObject({
+      event: "db.request.budget",
+      requestId: "p1",
+    });
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,7 @@ import type { SlowQueryDetectorConfig } from "./types";
  * Default configuration values
  */
 export const DEFAULT_CONFIG: Required<
-  Omit<SlowQueryDetectorConfig, "dbName" | "paramsRedactor" | "queryName">
+  Omit<SlowQueryDetectorConfig, "dbName" | "paramsRedactor" | "queryName" | "requestBudget">
 > = {
   warnThresholdMs: 200,
   errorThresholdMs: 1000,

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "async_hooks";
+import type { IContextProvider } from "./types";
 
 export type DbContext = {
   requestId?: string;
@@ -13,4 +14,17 @@ export const runWithDbContext = async <T>(context: DbContext, fn: () => Promise<
 
 export const getDbContext = (): DbContext => {
   return dbContextStorage.getStore() ?? {};
+};
+
+/**
+ * Safe read of optional context provider (never throws).
+ */
+export const resolveDetectorContext = (
+  contextProvider?: IContextProvider,
+): { requestId?: string; userId?: string } => {
+  try {
+    return contextProvider?.getContext() ?? {};
+  } catch {
+    return {};
+  }
 };

--- a/src/detector.ts
+++ b/src/detector.ts
@@ -10,11 +10,13 @@ import type {
   IEventSink,
   IExplainRunner,
 } from "./types";
+import { resolveDetectorContext } from "./context";
 import { startTimer } from "./timer";
 import { classifyQuery } from "./classifier";
 import { createQueryEvent } from "./eventFactory";
 import { shouldRunExplain } from "./explain/explainGate";
 import { ExplainThrottle } from "./explain/throttle";
+import { RequestBudgetTracker } from "./requestBudgetTracker";
 
 const readNumericRowCount = (result: unknown): number | undefined => {
   if (typeof result !== "object" || result === null) {
@@ -32,6 +34,7 @@ const readNumericRowCount = (result: unknown): number | undefined => {
  */
 export class SlowQueryDetector {
   private readonly explainThrottle: ExplainThrottle;
+  private readonly requestBudgetTracker: RequestBudgetTracker | undefined;
 
   constructor(
     public readonly config: SlowQueryDetectorConfig,
@@ -40,6 +43,12 @@ export class SlowQueryDetector {
     public explainRunner?: IExplainRunner,
   ) {
     this.explainThrottle = new ExplainThrottle();
+    const rb = config.requestBudget;
+    const budgetEnabled =
+      rb !== undefined && (rb.maxQueries !== undefined || rb.maxTotalDurationMs !== undefined);
+    this.requestBudgetTracker = budgetEnabled
+      ? new RequestBudgetTracker(rb.maxTrackedRequests)
+      : undefined;
   }
 
   /**
@@ -98,6 +107,30 @@ export class SlowQueryDetector {
         } catch {
           // Don't fail query if sink fails - log but continue
           // Sink errors should not break query execution
+        }
+      }
+
+      const budget = this.config.requestBudget;
+      if (this.requestBudgetTracker && budget) {
+        const ctx = resolveDetectorContext(this.contextProvider);
+        const requestId = ctx.requestId;
+        if (requestId !== undefined && requestId !== "") {
+          const violation = this.requestBudgetTracker.record(
+            requestId,
+            ctx.userId,
+            durationMs,
+            budget,
+            this.config.dbName,
+          );
+          if (violation !== undefined) {
+            for (const sink of this.sinks) {
+              try {
+                sink.handle(violation);
+              } catch {
+                // Ignore sink errors
+              }
+            }
+          }
         }
       }
 

--- a/src/eventFactory.ts
+++ b/src/eventFactory.ts
@@ -9,6 +9,7 @@ import type {
   SlowQueryDetectorConfig,
   IContextProvider,
 } from "./types";
+import { resolveDetectorContext } from "./context";
 import { sanitizeSql, redactParams } from "./redaction";
 
 /**
@@ -20,14 +21,7 @@ export function createQueryEvent(
   config: SlowQueryDetectorConfig,
   contextProvider?: IContextProvider,
 ): QueryEvent {
-  // Safely get context with error handling
-  let context: { requestId?: string; userId?: string } = {};
-  try {
-    context = contextProvider?.getContext() ?? {};
-  } catch {
-    // Context provider errors should not break event creation
-    // Context is optional metadata
-  }
+  const context = resolveDetectorContext(contextProvider);
 
   const sanitizedSql = sanitizeSql(metadata.sql);
   const redactedParams = redactParams(metadata.params, config.paramsRedactor);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 import type { SlowQueryDetectorConfig, ILogger, IContextProvider, IEventSink } from "./types";
+import { getDbContext } from "./context";
 import { SlowQueryDetector } from "./detector";
 import { LoggerSink } from "./sinks/loggerSink";
 import { wrapQueryFn } from "./wrappers/wrapQueryFn";
@@ -32,7 +33,11 @@ export function createSlowQueryDetector(
     );
   }
 
-  return new SlowQueryDetector(config, deps.contextProvider, sinks);
+  const contextProvider = deps.contextProvider ?? {
+    getContext: () => getDbContext(),
+  };
+
+  return new SlowQueryDetector(config, contextProvider, sinks);
 }
 
 export { wrapQueryFn, wrapTaggedTemplate };
@@ -46,6 +51,9 @@ export type {
   SlowQueryDetectorConfig,
   QueryEvent,
   QuerySubtype,
+  RequestBudgetConfig,
+  RequestBudgetViolationEvent,
+  DetectorEvent,
 } from "./types";
 
 export { getDbContext, runWithDbContext, type DbContext } from "./context";

--- a/src/requestBudgetTracker.ts
+++ b/src/requestBudgetTracker.ts
@@ -1,0 +1,83 @@
+/**
+ * In-memory per-requestId aggregation with LRU eviction.
+ */
+
+import type { RequestBudgetConfig, RequestBudgetViolationEvent } from "./types";
+
+type Entry = {
+  queryCount: number;
+  totalDurationMs: number;
+  violationEmitted: boolean;
+};
+
+const DEFAULT_MAX_TRACKED = 5000;
+
+export class RequestBudgetTracker {
+  private readonly map = new Map<string, Entry>();
+  private readonly maxTracked: number;
+
+  constructor(maxTrackedRequests?: number) {
+    const raw = maxTrackedRequests ?? DEFAULT_MAX_TRACKED;
+    const resolved = Number.isFinite(raw) ? raw : DEFAULT_MAX_TRACKED;
+    this.maxTracked = Math.max(1, Math.floor(resolved));
+  }
+
+  record(
+    requestId: string,
+    userId: string | undefined,
+    durationMs: number,
+    budget: RequestBudgetConfig,
+    dbName: string | undefined,
+  ): RequestBudgetViolationEvent | undefined {
+    if (this.map.size >= this.maxTracked && !this.map.has(requestId)) {
+      const oldest = this.map.keys().next().value;
+      if (oldest !== undefined) {
+        this.map.delete(oldest);
+      }
+    }
+
+    const prev = this.map.get(requestId) ?? {
+      queryCount: 0,
+      totalDurationMs: 0,
+      violationEmitted: false,
+    };
+
+    const next: Entry = {
+      queryCount: prev.queryCount + 1,
+      totalDurationMs: prev.totalDurationMs + durationMs,
+      violationEmitted: prev.violationEmitted,
+    };
+
+    this.map.delete(requestId);
+    this.map.set(requestId, next);
+
+    if (next.violationEmitted) {
+      return undefined;
+    }
+
+    const overQueries = budget.maxQueries !== undefined && next.queryCount > budget.maxQueries;
+    const overTotal =
+      budget.maxTotalDurationMs !== undefined && next.totalDurationMs > budget.maxTotalDurationMs;
+
+    if (!overQueries && !overTotal) {
+      return undefined;
+    }
+
+    next.violationEmitted = true;
+    this.map.set(requestId, next);
+
+    const event: RequestBudgetViolationEvent = {
+      event: "db.request.budget",
+      subtype: "violation",
+      timestamp: new Date().toISOString(),
+      requestId,
+      userId,
+      queryCount: next.queryCount,
+      totalDurationMs: next.totalDurationMs,
+      maxQueries: budget.maxQueries,
+      maxTotalDurationMs: budget.maxTotalDurationMs,
+      dbName,
+    };
+    return event;
+  }
+}

--- a/src/sinks/loggerSink.ts
+++ b/src/sinks/loggerSink.ts
@@ -2,7 +2,7 @@
  * Logger-based event sink implementation
  */
 
-import type { IEventSink, ILogger, QueryEvent } from "../types";
+import type { DetectorEvent, IEventSink, ILogger } from "../types";
 import { DEFAULT_CONFIG } from "../config";
 
 /**
@@ -17,7 +17,12 @@ export class LoggerSink implements IEventSink {
     },
   ) {}
 
-  handle(event: QueryEvent): void {
+  handle(event: DetectorEvent): void {
+    if (event.event === "db.request.budget") {
+      this.logger.warn(event);
+      return;
+    }
+
     const sampleRateNormal = this.config.sampleRateNormal ?? DEFAULT_CONFIG.sampleRateNormal;
 
     switch (event.subtype) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,16 @@
 export type QuerySubtype = "normal" | "slow" | "very_slow" | "error";
 
 /**
+ * Per-request aggregate limits (requires requestId on context).
+ */
+export interface RequestBudgetConfig {
+  maxQueries?: number;
+  maxTotalDurationMs?: number;
+  /** Max distinct requestIds held in memory; LRU eviction. Default 5000. */
+  maxTrackedRequests?: number;
+}
+
+/**
  * Logger interface for dependency injection
  */
 export interface ILogger {
@@ -38,13 +48,6 @@ export interface IExplainRunner {
 }
 
 /**
- * Event sink interface for extensibility
- */
-export interface IEventSink {
-  handle(event: QueryEvent): void;
-}
-
-/**
  * Slow query detector configuration
  */
 export interface SlowQueryDetectorConfig {
@@ -58,6 +61,7 @@ export interface SlowQueryDetectorConfig {
   explainThresholdMs?: number; // default: 5000
   dbName?: string;
   paramsRedactor?: (params: unknown[]) => unknown[];
+  requestBudget?: RequestBudgetConfig;
 }
 
 /**
@@ -90,4 +94,29 @@ export interface QueryMetadata {
   rowCount?: number;
   queryName?: string;
   error?: Error;
+}
+
+/**
+ * Emitted once per requestId when aggregate limits are exceeded.
+ */
+export interface RequestBudgetViolationEvent {
+  event: "db.request.budget";
+  subtype: "violation";
+  timestamp: string;
+  requestId: string;
+  userId?: string;
+  queryCount: number;
+  totalDurationMs: number;
+  maxQueries?: number;
+  maxTotalDurationMs?: number;
+  dbName?: string;
+}
+
+export type DetectorEvent = QueryEvent | RequestBudgetViolationEvent;
+
+/**
+ * Event sink interface for extensibility
+ */
+export interface IEventSink {
+  handle(event: DetectorEvent): void;
 }


### PR DESCRIPTION
## Summary

Adds **per-`requestId` query budgets** (`maxQueries`, `maxTotalDurationMs`, optional `maxTrackedRequests`) with a single **`db.request.budget`** emission per id when either limit is crossed first. Refreshes **README** and **GitHub Pages** (`docs/index.html`) so imports and examples match the driver-agnostic API and **`@olegkoval/queryd/prisma`**.

---

## Usage (quick examples)

**1. Budgets + postgres.js (tagged template)**

```ts
import postgres from "postgres";
import {
  createSlowQueryDetector,
  wrapTaggedTemplate,
  createConsoleLogger,
  runWithDbContext,
} from "@olegkoval/queryd";

const sql = postgres(process.env.DATABASE_URL!);
const detector = createSlowQueryDetector(
  {
    warnThresholdMs: 200,
    requestBudget: { maxQueries: 80, maxTotalDurationMs: 2_000 },
  },
  { logger: createConsoleLogger() },
);
const instrumentedSql = wrapTaggedTemplate(sql, detector);

await runWithDbContext({ requestId: "req-abc" }, async () => {
  await instrumentedSql`select 1`;
});
```

**2. Prisma (subpath import)**

```ts
import { PrismaClient } from "@prisma/client";
import { createSlowQueryDetector, createConsoleLogger, runWithDbContext } from "@olegkoval/queryd";
import { wrapPrismaClient } from "@olegkoval/queryd/prisma";

const detector = createSlowQueryDetector(
  { warnThresholdMs: 200, requestBudget: { maxQueries: 80 } },
  { logger: createConsoleLogger() },
);
export const prisma = wrapPrismaClient(new PrismaClient(), detector);
```

**3. Custom sink — branch on budget events**

```ts
sink.handle(event) {
  if (event.event === "db.request.budget") {
    // RequestBudgetViolationEvent — no sql on this branch
    return;
  }
  // QueryEvent …
}
```

Full snippets: [README.md](https://github.com/oleg-koval/slow-query-detector/blob/feat/request-budget-and-docs-examples/README.md) · [docs site](https://oleg-koval.github.io/slow-query-detector/).

---

## What changed (high level)

- **Runtime:** `RequestBudgetTracker`, `RequestBudgetViolationEvent`, `DetectorEvent`, `LoggerSink` warning on budget hit.
- **Docs:** Correct `wrapPrismaClient` import from `@olegkoval/queryd/prisma`; hero + three copyable panels (Prisma, postgres.js, `wrapQueryFn`); calmer landing styling.
- **Tests:** Budget + detector coverage; dual-limit de-duplication test uses real `maxTotalDurationMs: 20` + slow query so cumulative duration exceeds the cap after the first violation path.

---

## Testing

```bash
npm test
npm run build
npm run lint
```

---

@oleg-koval — ready for review when you are.
