### PR TITLE
docs: request budget background, practices, and sources

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -14,6 +14,10 @@ permissions:
   checks: write
   id-token: write
 
+# Skip Husky hook installation in CI (hooks are for local commits only).
+env:
+  HUSKY: 0
+
 jobs:
   # Separate jobs so each name appears as a GitHub status check (branch protection).
   lint:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+set -e
+npm run lint
+npm run format:check
+npm test

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ npm install @olegkoval/queryd
 
 Add `@prisma/client` only if you use the Prisma entry (see below).
 
+### Git hooks (contributors)
+
+`npm install` enables a **pre-commit** hook ([Husky](https://typicode.github.io/husky/)) that runs **`npm run lint`**, **`npm run format:check`**, and **`npm test`**. To skip hooks for a one-off commit: `HUSKY=0 git commit …`.
+
 ## Usage (any stack)
 
 `SlowQueryDetector.executeQuery` runs your callback and emits structured events (`QueryEvent` for each query, and optionally `RequestBudgetViolationEvent` — see [Request budgets](#request-budgets-per-requestid)). Wrappers cover common shapes:

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ await runWithDbContext({ requestId: "job-7" }, async () => {
 
 ## Request budgets (per `requestId`)
 
+Background, practices, and sources: **[docs/budget.md](./docs/budget.md)**.
+
 Set `requestBudget.maxQueries` and/or `requestBudget.maxTotalDurationMs` to catch **query storms** (many fast queries) that stay under single-query latency thresholds. Counts and duration are summed **per `requestId`** for the lifetime of that id in the LRU map (in-process only).
 
 - **Successful and failed** `executeQuery` completions both increment the budget (every round-trip attempt counts).

--- a/docs/budget.md
+++ b/docs/budget.md
@@ -1,0 +1,67 @@
+# Request budgets and database work per request
+
+This document explains **what “budget” means** in reliability literature, **good practices** for limiting database work per application request, and **how queryd’s `requestBudget` feature** fits in (with links to sources).
+
+## Terminology: three different “budgets”
+
+| Concept | Typical meaning | Relationship to queryd |
+| -------- | ---------------- | ------------------------ |
+| **SRE error budget** | Allowed rate of **SLO misses** (e.g. availability or latency objectives); used to balance reliability vs change velocity. | **Not the same thing.** queryd does not compute SLO compliance or error budgets. See [Service Level Objectives](https://sre.google/sre-book/service-level-objectives/) and [Embracing Risk](https://sre.google/sre-book/embracing-risk/) (motivation for error budgets). |
+| **End-user / latency budget** | Share of total request time allocated to each hop (browser, CDN, app, DB) so the **overall** request stays within a target. | queryd’s `maxTotalDurationMs` is an **aggregate DB time per `requestId`**, not a full end-to-end latency budget—but it aligns with the idea of capping how much wall-clock time DB work can consume inside one logical request. Monitoring guidance often groups **latency** with other “golden signals” ([Monitoring Distributed Systems](https://sre.google/sre-book/monitoring-distributed-systems/)). |
+| **Per-request DB budget (this library)** | Optional caps on **how many SQL round-trips** and/or **total measured DB duration** apply to one **`requestId`** before emitting a **`db.request.budget`** event. | This is what `requestBudget` implements. It is **observability and alerting**, not a hard stop: queries still run unless **you** add policy on top of events. |
+
+## How queryd request budgets work
+
+Configure `requestBudget` on `SlowQueryDetectorConfig`:
+
+- **`maxQueries`** — maximum number of completed `executeQuery` calls (success or error) per `requestId`.
+- **`maxTotalDurationMs`** — maximum **sum** of per-query durations for that `requestId`.
+- **`maxTrackedRequests`** — LRU size for in-memory state (default 5000).
+
+Behavior (see [README § Request budgets](../README.md#request-budgets-per-requestid)):
+
+1. Budgets apply only when **`requestId`** is set on context (e.g. via `runWithDbContext`). With **`createSlowQueryDetector`**, the default `contextProvider` reads that context; custom detectors must supply one (see [README](../README.md#request-budgets-per-requestid)).
+2. Each query completion increments **count** and adds **duration** to that `requestId`.
+3. The **first** time either limit is exceeded, sinks receive **one** `RequestBudgetViolationEvent` (`event: "db.request.budget"`). Further violations for the same id only happen after that id is evicted from the LRU map.
+4. **`LoggerSink`** logs budget events at **warn** level (see `LoggerSink` in source).
+
+This design targets **query storms**: many fast queries that never cross a single-query `warnThresholdMs`, but still hurt latency, CPU, and pool usage.
+
+## Industry context: why cap queries or cost per operation?
+
+- **N+1 patterns** — One initial query plus N per-row queries is a classic ORM issue; each subquery may be “fast” while the pattern is still pathological. See [Handling the N+1 problem](https://www.apollographql.com/docs/graphos/schema-design/guides/handling-n-plus-one) (GraphQL/API layer) and [Performance](https://graphql.org/learn/performance/) (batching, lookahead, and related ideas).
+- **Operation cost limits** — GraphQL ecosystems often use **complexity** or **depth** limits so a single client operation cannot do unbounded work ([Operation complexity controls](https://graphql-js.org/docs/operation-complexity-controls/)). That is **static analysis of the operation**; queryd instead measures **actual** round-trips and time at runtime for the instrumented client.
+- **SLO thinking** — Services define SLIs (e.g. latency) and SLOs; teams use **error budgets** to tolerate a controlled rate of misses ([Service Level Objectives](https://sre.google/sre-book/service-level-objectives/)). Per-request DB caps are a **narrow, implementable signal** that your app’s data layer is not exploding for a single request—complementary to service-level SLOs.
+
+## Good practices for `requestBudget` limits
+
+1. **Baseline before tightening** — Use existing metrics (p50/p95 query count and DB time per route) or staging load tests. Pick limits that **rarely fire** in healthy traffic and **do fire** when N+1 or fan-out bugs appear.
+2. **Different routes, different budgets** — Read-heavy list endpoints may legitimately use more queries than a simple mutation; if you use one process-wide detector config, choose limits that fit your **worst acceptable** “normal” path or use separate detector instances per surface if needed.
+3. **Pair with single-query thresholds** — `warnThresholdMs` / `errorThresholdMs` catch **slow individual** queries; `requestBudget` catches **many small** queries. Use both.
+4. **Treat violations as signals** — Wire `db.request.budget` to your log/metrics backend (e.g. Sentry, Datadog) and alert with **low noise**: one event per `requestId` per violation window keeps cardinality manageable.
+5. **Remember process boundaries** — Tracking is **in-process** and keyed by `requestId`. It does not aggregate across app instances; for cluster-wide enforcement you still need shared counters or edge limits.
+6. **Memory** — Adjust `maxTrackedRequests` if you have very high concurrency of unique ids.
+
+## How this feature helps users
+
+| User goal | How queryd helps |
+| ---------- | ----------------- |
+| Find **N+1** or accidental fan-out | Many queries stay under per-query ms thresholds but **trip `maxQueries`** or **`maxTotalDurationMs`**, producing a structured **`db.request.budget`** event with counts and totals. |
+| **Alert** without parsing every query log | One **warn-level** (or custom sink) event per offending `requestId` reduces noise versus logging every query. |
+| **Correlate** to traffic | Events include **`requestId`** and optional **`userId`** (from context) for support and debugging. |
+| **Integrate** with existing observability | Custom **`IEventSink`** implementations can route `event === "db.request.budget"` to metrics, tickets, or paging ([README](../README.md#request-budgets-per-requestid)). |
+
+**Non-goals:** queryd does not **reject** or **cancel** queries when a budget is exceeded; it **observes** and **emits**. Hard enforcement requires application or database-layer controls in addition to this library.
+
+## References (URLs)
+
+- Google SRE Book — [Service Level Objectives](https://sre.google/sre-book/service-level-objectives/) (SLIs, SLOs, error budgets).
+- Google SRE Book — [Embracing Risk](https://sre.google/sre-book/embracing-risk/) (motivation for error budgets).
+- Google SRE Book — [Monitoring Distributed Systems](https://sre.google/sre-book/monitoring-distributed-systems/) (latency, traffic, and alerting philosophy).
+- Apollo GraphQL — [Handling the N+1 problem](https://www.apollographql.com/docs/graphos/schema-design/guides/handling-n-plus-one).
+- GraphQL — [Performance](https://graphql.org/learn/performance/).
+- GraphQL.js — [Operation complexity controls](https://graphql-js.org/docs/operation-complexity-controls/).
+
+---
+
+*Package: [@olegkoval/queryd](https://www.npmjs.com/package/@olegkoval/queryd) · Repo README: [Request budgets](../README.md#request-budgets-per-requestid).*

--- a/docs/budget.md
+++ b/docs/budget.md
@@ -4,11 +4,11 @@ This document explains **what “budget” means** in reliability literature, **
 
 ## Terminology: three different “budgets”
 
-| Concept | Typical meaning | Relationship to queryd |
-| -------- | ---------------- | ------------------------ |
-| **SRE error budget** | Allowed rate of **SLO misses** (e.g. availability or latency objectives); used to balance reliability vs change velocity. | **Not the same thing.** queryd does not compute SLO compliance or error budgets. See [Service Level Objectives](https://sre.google/sre-book/service-level-objectives/) and [Embracing Risk](https://sre.google/sre-book/embracing-risk/) (motivation for error budgets). |
-| **End-user / latency budget** | Share of total request time allocated to each hop (browser, CDN, app, DB) so the **overall** request stays within a target. | queryd’s `maxTotalDurationMs` is an **aggregate DB time per `requestId`**, not a full end-to-end latency budget—but it aligns with the idea of capping how much wall-clock time DB work can consume inside one logical request. Monitoring guidance often groups **latency** with other “golden signals” ([Monitoring Distributed Systems](https://sre.google/sre-book/monitoring-distributed-systems/)). |
-| **Per-request DB budget (this library)** | Optional caps on **how many SQL round-trips** and/or **total measured DB duration** apply to one **`requestId`** before emitting a **`db.request.budget`** event. | This is what `requestBudget` implements. It is **observability and alerting**, not a hard stop: queries still run unless **you** add policy on top of events. |
+| Concept                                  | Typical meaning                                                                                                                                                   | Relationship to queryd                                                                                                                                                                                                                                                                                                                                                                                    |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **SRE error budget**                     | Allowed rate of **SLO misses** (e.g. availability or latency objectives); used to balance reliability vs change velocity.                                         | **Not the same thing.** queryd does not compute SLO compliance or error budgets. See [Service Level Objectives](https://sre.google/sre-book/service-level-objectives/) and [Embracing Risk](https://sre.google/sre-book/embracing-risk/) (motivation for error budgets).                                                                                                                                  |
+| **End-user / latency budget**            | Share of total request time allocated to each hop (browser, CDN, app, DB) so the **overall** request stays within a target.                                       | queryd’s `maxTotalDurationMs` is an **aggregate DB time per `requestId`**, not a full end-to-end latency budget—but it aligns with the idea of capping how much wall-clock time DB work can consume inside one logical request. Monitoring guidance often groups **latency** with other “golden signals” ([Monitoring Distributed Systems](https://sre.google/sre-book/monitoring-distributed-systems/)). |
+| **Per-request DB budget (this library)** | Optional caps on **how many SQL round-trips** and/or **total measured DB duration** apply to one **`requestId`** before emitting a **`db.request.budget`** event. | This is what `requestBudget` implements. It is **observability and alerting**, not a hard stop: queries still run unless **you** add policy on top of events.                                                                                                                                                                                                                                             |
 
 ## How queryd request budgets work
 
@@ -44,12 +44,12 @@ This design targets **query storms**: many fast queries that never cross a singl
 
 ## How this feature helps users
 
-| User goal | How queryd helps |
-| ---------- | ----------------- |
-| Find **N+1** or accidental fan-out | Many queries stay under per-query ms thresholds but **trip `maxQueries`** or **`maxTotalDurationMs`**, producing a structured **`db.request.budget`** event with counts and totals. |
-| **Alert** without parsing every query log | One **warn-level** (or custom sink) event per offending `requestId` reduces noise versus logging every query. |
-| **Correlate** to traffic | Events include **`requestId`** and optional **`userId`** (from context) for support and debugging. |
-| **Integrate** with existing observability | Custom **`IEventSink`** implementations can route `event === "db.request.budget"` to metrics, tickets, or paging ([README](../README.md#request-budgets-per-requestid)). |
+| User goal                                 | How queryd helps                                                                                                                                                                    |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Find **N+1** or accidental fan-out        | Many queries stay under per-query ms thresholds but **trip `maxQueries`** or **`maxTotalDurationMs`**, producing a structured **`db.request.budget`** event with counts and totals. |
+| **Alert** without parsing every query log | One **warn-level** (or custom sink) event per offending `requestId` reduces noise versus logging every query.                                                                       |
+| **Correlate** to traffic                  | Events include **`requestId`** and optional **`userId`** (from context) for support and debugging.                                                                                  |
+| **Integrate** with existing observability | Custom **`IEventSink`** implementations can route `event === "db.request.budget"` to metrics, tickets, or paging ([README](../README.md#request-budgets-per-requestid)).            |
 
 **Non-goals:** queryd does not **reject** or **cancel** queries when a budget is exceeded; it **observes** and **emits**. Hard enforcement requires application or database-layer controls in addition to this library.
 
@@ -64,4 +64,4 @@ This design targets **query storms**: many fast queries that never cross a singl
 
 ---
 
-*Package: [@olegkoval/queryd](https://www.npmjs.com/package/@olegkoval/queryd) · Repo README: [Request budgets](../README.md#request-budgets-per-requestid).*
+_Package: [@olegkoval/queryd](https://www.npmjs.com/package/@olegkoval/queryd) · Repo README: [Request budgets](../README.md#request-budgets-per-requestid)._

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/node": "^25.6.0",
         "@vitest/coverage-v8": "^4.1.4",
         "eslint": "^10.2.0",
+        "husky": "^9.1.7",
         "prettier": "^3.8.3",
         "semantic-release": "^24.0.0",
         "typescript": "^6.0.2",
@@ -28,6 +29,11 @@
       },
       "peerDependencies": {
         "@prisma/client": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@prisma/client": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2992,6 +2998,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ignore": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "format:check": "prettier --check \"**/*.{ts,js,json,md,yml,yaml}\"",
     "typecheck": "tsc --noEmit",
     "test:coverage": "vitest run --coverage",
-    "prepare": "npm run build",
+    "prepare": "husky && npm run build",
     "release:dry-run": "semantic-release --dry-run",
     "semantic-release": "semantic-release"
   },
@@ -69,6 +69,7 @@
     "@types/node": "^25.6.0",
     "@vitest/coverage-v8": "^4.1.4",
     "eslint": "^10.2.0",
+    "husky": "^9.1.7",
     "prettier": "^3.8.3",
     "semantic-release": "^24.0.0",
     "typescript": "^6.0.2",


### PR DESCRIPTION
## Summary

Adds **[docs/budget.md](https://github.com/oleg-koval/slow-query-detector/blob/docs/budget-background-pr/docs/budget.md)** clarifying SRE vs per-request DB budgets, good practices for `requestBudget` limits, how the feature helps users, and sourced references. Links from [README Request budgets](https://github.com/oleg-koval/slow-query-detector/blob/docs/budget-background-pr/README.md#request-budgets-per-requestid).

## Usage

**Read the new doc (local clone):**

```bash
# From repo root
open docs/budget.md   # macOS
# or: less docs/budget.md
```

**Discover from README after merge:** follow *Background, practices, and sources* under **Request budgets** → `./docs/budget.md`.

**No API or config changes** — existing `requestBudget` usage is unchanged. Example remains:

```ts
const detector = createSlowQueryDetector(
  {
    warnThresholdMs: 200,
    requestBudget: { maxQueries: 80, maxTotalDurationMs: 2_000 },
  },
  { logger: createConsoleLogger() },
);
```

Custom sinks: branch on `event.event === "db.request.budget"` as documented in README.

## Review notes

- Terminology table distinguishes SRE error budgets from queryd’s aggregate per-`requestId` limits.
- Explicit **non-goal**: observability only (no query cancellation).
- References include sre.google SLO/monitoring chapters, Apollo N+1, GraphQL performance/complexity docs.
