### PR TITLE
fix: normalize invalid maxQueries for request budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ await runWithDbContext({ requestId: "job-7" }, async () => {
 
 Background, practices, and sources: **[docs/budget.md](./docs/budget.md)**.
 
-Set `requestBudget.maxQueries` and/or `requestBudget.maxTotalDurationMs` to catch **query storms** (many fast queries) that stay under single-query latency thresholds. Counts and duration are summed **per `requestId`** for the lifetime of that id in the LRU map (in-process only).
+Set `requestBudget.maxQueries` and/or `requestBudget.maxTotalDurationMs` to catch **query storms** (many fast queries) that stay under single-query latency thresholds. Counts and duration are summed **per `requestId`** for the lifetime of that id in the LRU map (in-process only). Negative or non-finite `maxQueries` values are ignored (no cap on query count); use `0` to mean “no queries allowed” before the first violation.
 
 - **Successful and failed** `executeQuery` completions both increment the budget (every round-trip attempt counts).
 - The first time a limit is exceeded for a `requestId`, sinks receive one **`db.request.budget`** event (`LoggerSink` → **warn**). A second violation for the same id is only possible after that id falls out of the LRU (e.g. many concurrent requests with unique ids).

--- a/docs/budget.md
+++ b/docs/budget.md
@@ -14,7 +14,7 @@ This document explains **what “budget” means** in reliability literature, **
 
 Configure `requestBudget` on `SlowQueryDetectorConfig`:
 
-- **`maxQueries`** — maximum number of completed `executeQuery` calls (success or error) per `requestId`.
+- **`maxQueries`** — maximum number of completed `executeQuery` calls (success or error) per `requestId`. Omit the field (or only set `maxTotalDurationMs`) for no cap on count. **`0`** means the first query exceeds the budget. **Negative or non-finite** values are treated as **no cap** (same as omitting the field).
 - **`maxTotalDurationMs`** — maximum **sum** of per-query durations for that `requestId`.
 - **`maxTrackedRequests`** — LRU size for in-memory state (default 5000).
 

--- a/src/__tests__/requestBudgetTracker.test.ts
+++ b/src/__tests__/requestBudgetTracker.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { RequestBudgetTracker } from "../requestBudgetTracker";
+import { RequestBudgetTracker, effectiveMaxQueries } from "../requestBudgetTracker";
 
 describe("RequestBudgetTracker", () => {
   it("emits violation when query count exceeds maxQueries", () => {
@@ -104,6 +104,36 @@ describe("RequestBudgetTracker", () => {
     for (let i = 0; i < 5; i++) {
       expect(t.record("nan-q", undefined, 1, budget, undefined)).toBeUndefined();
     }
+  });
+
+  it("treats negative maxQueries as no query-count cap", () => {
+    const t = new RequestBudgetTracker(50);
+    const budget = { maxQueries: -1 };
+    for (let i = 0; i < 20; i++) {
+      expect(t.record("neg-cap", undefined, 1, budget, undefined)).toBeUndefined();
+    }
+  });
+
+  it("still applies maxTotalDurationMs when maxQueries is negative", () => {
+    const t = new RequestBudgetTracker(50);
+    const budget = { maxQueries: -1, maxTotalDurationMs: 5 };
+    expect(t.record("neg-plus-dur", undefined, 3, budget, undefined)).toBeUndefined();
+    expect(t.record("neg-plus-dur", undefined, 3, budget, undefined)).toMatchObject({
+      event: "db.request.budget",
+      totalDurationMs: 6,
+      maxQueries: undefined,
+      maxTotalDurationMs: 5,
+    });
+  });
+
+  it("effectiveMaxQueries matches runtime policy", () => {
+    expect(effectiveMaxQueries(undefined)).toBeUndefined();
+    expect(effectiveMaxQueries(0)).toBe(0);
+    expect(effectiveMaxQueries(3)).toBe(3);
+    expect(effectiveMaxQueries(-1)).toBeUndefined();
+    expect(effectiveMaxQueries(Number.NaN)).toBeUndefined();
+    expect(effectiveMaxQueries(Number.POSITIVE_INFINITY)).toBeUndefined();
+    expect(effectiveMaxQueries(Number.NEGATIVE_INFINITY)).toBeUndefined();
   });
 
   it("treats negative maxTotalDurationMs as an immediately exceeded time cap", () => {

--- a/src/requestBudgetTracker.ts
+++ b/src/requestBudgetTracker.ts
@@ -12,6 +12,24 @@ type Entry = {
 
 const DEFAULT_MAX_TRACKED = 5000;
 
+/**
+ * Resolves the query-count cap used for comparisons and emitted events.
+ * Negative or non-finite values are treated as "no cap" (same as omitting the field).
+ * Zero is preserved: it means no queries are allowed before violation.
+ */
+export function effectiveMaxQueries(maxQueries: number | undefined): number | undefined {
+  if (maxQueries === undefined) {
+    return undefined;
+  }
+  if (maxQueries === 0) {
+    return 0;
+  }
+  if (!Number.isFinite(maxQueries) || maxQueries < 0) {
+    return undefined;
+  }
+  return maxQueries;
+}
+
 export class RequestBudgetTracker {
   private readonly map = new Map<string, Entry>();
   private readonly maxTracked: number;
@@ -55,7 +73,8 @@ export class RequestBudgetTracker {
       return undefined;
     }
 
-    const overQueries = budget.maxQueries !== undefined && next.queryCount > budget.maxQueries;
+    const cap = effectiveMaxQueries(budget.maxQueries);
+    const overQueries = cap !== undefined && next.queryCount > cap;
     const overTotal =
       budget.maxTotalDurationMs !== undefined && next.totalDurationMs > budget.maxTotalDurationMs;
 
@@ -74,7 +93,7 @@ export class RequestBudgetTracker {
       userId,
       queryCount: next.queryCount,
       totalDurationMs: next.totalDurationMs,
-      maxQueries: budget.maxQueries,
+      maxQueries: cap,
       maxTotalDurationMs: budget.maxTotalDurationMs,
       dbName,
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export type QuerySubtype = "normal" | "slow" | "very_slow" | "error";
  * Per-request aggregate limits (requires requestId on context).
  */
 export interface RequestBudgetConfig {
+  /** Max completed queries per `requestId`. Omit or use only `maxTotalDurationMs` for no query cap. `0` means the first query trips the budget. Negative or non-finite values are ignored (no cap). */
   maxQueries?: number;
   maxTotalDurationMs?: number;
   /** Max distinct requestIds held in memory; LRU eviction. Default 5000. */


### PR DESCRIPTION
## Summary

Closes negative / non-finite `requestBudget.maxQueries` behavior described in #19: those values no longer act as a confusing query-count cap. **`maxQueries === 0`** is unchanged (first completed query violates).

## Usage

**Invalid query-count caps are ignored** (same as omitting `maxQueries`); **`0` still means “no queries allowed” before the first violation.**

```ts
import { createSlowQueryDetector, createConsoleLogger } from "@olegkoval/queryd";

// Negative or non-finite maxQueries → no cap on query count; duration limit still applies.
createSlowQueryDetector(
  {
    warnThresholdMs: 200,
    requestBudget: { maxQueries: -1, maxTotalDurationMs: 2_000 },
  },
  { logger: createConsoleLogger() },
);

// Explicit “deny any query” (unchanged):
createSlowQueryDetector(
  { warnThresholdMs: 200, requestBudget: { maxQueries: 0 } },
  { logger: createConsoleLogger() },
);
```

`RequestBudgetViolationEvent.maxQueries` reflects the **effective** cap (`undefined` when the query limit is not applied).

Fixes #19


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated request budget documentation to clarify `maxQueries` handling: negative or non-finite values are treated as no cap, `0` means first query violates budget, and omitting it removes the query-count constraint.

* **New Features**
  * Exported `effectiveMaxQueries` utility for normalizing query limits.

* **Tests**
  * Added comprehensive coverage for `maxQueries` edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->